### PR TITLE
Fixed main, refactored build, rewrote readme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,0 @@
-EMAIL_HOST = 'smtp.example.com'
-EMAIL_PORT = '465' #Keep the same if using SSL
-EMAIL_FROM='sender@example.com'
-EMAIL_TO='reciever@example.com'

--- a/build_badtrack.py
+++ b/build_badtrack.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
     EMAIL_HOST = 'relay.mailbaby.net'
     EMAIL_PORT = '465'
     EMAIL_FROM = 'sender@obsi.com.au'
-    EMAIL_TO = 'yannstaggl@gmail.com'
+    EMAIL_TO = 'robinchew@gmail.com'
     """)
 
     # Setup service file

--- a/build_badtrack.py
+++ b/build_badtrack.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
     # Setup text files
 
     # Setup environment file
-    envfile_text = inspect.cleandoc(f"""\
+    envfile_content = inspect.cleandoc(f"""\
     EMAIL_HOST = 'relay.mailbaby.net'
     EMAIL_PORT = '465'
     EMAIL_FROM = 'sender@obsi.com.au'
@@ -145,7 +145,7 @@ if __name__ == '__main__':
     # Add files to package
     package_file("/DEBIAN/control",contents=control_content)
     package_file("/DEBIAN/postinst",contents=postinst_content)
-    package_file("/var/lib/badtrack/.env",contents=envfile_text)
+    package_file("/var/lib/badtrack/.env",contents=envfile_content)
     package_file("/etc/systemd/system/badtrack.service",contents=service_content)
     package_file("/usr/local/bin/badtrack/main.py",existing_file="main.py")
 

--- a/build_badtrack.py
+++ b/build_badtrack.py
@@ -3,103 +3,159 @@
 import os
 import shutil
 import subprocess
+import inspect
 
 # Get the current working directory
 APP_PATH = os.path.abspath(os.path.dirname(__file__))
+PACKAGE_NAME = "badtrack"
 
 # Fixed path for the environment variable folders
 HISTORY_FOLDER = "/var/lib/badtrack/history"
 CACHE_FOLDER = "/var/lib/badtrack/cache"
 
-# Create the badtrack directory structure
-os.makedirs(f"{APP_PATH}/badtrack/DEBIAN", exist_ok=True)
-os.makedirs(f"{APP_PATH}/badtrack/usr/local/bin/badtrack", exist_ok=True)
-os.makedirs(f"{APP_PATH}/badtrack/etc/systemd/system", exist_ok=True)
-os.makedirs(f"{APP_PATH}/badtrack/var/lib/badtrack/history", exist_ok=True)
-os.makedirs(f"{APP_PATH}/badtrack/var/lib/badtrack/cache", exist_ok=True)
 
-# Write Environment File
-envfile_text = f"""\
-EMAIL_HOST = 'relay.mailbaby.net'
-EMAIL_PORT = '465'
-EMAIL_FROM ='sender@obsi.com.au'
-EMAIL_TO ='robinchew@gmail.com'
-"""
-with open (f"{APP_PATH}/badtrack/var/lib/badtrack/.env","w+") as envfile:
-    envfile.write(envfile_text)
-
-# Set permissions for envfile
-os.chmod(f"{APP_PATH}/badtrack/var/lib/badtrack/.env", 0o755)
-
-# Copy the main.py file to the badtrack directory and make it executable
-shutil.copy('main.py', f"{APP_PATH}/badtrack/usr/local/bin/badtrack/main.py")
-os.chmod(f"{APP_PATH}/badtrack/usr/local/bin/badtrack/main.py", 0o755)
-
-# Set perissions for environment variable folders.
-os.chmod(f"{APP_PATH}/badtrack/var/lib/badtrack/history",0o755)
-os.chmod(f"{APP_PATH}/badtrack/var/lib/badtrack/cache",0o755)
-
-# Create the control file. Reference for dependencies: https://www.debian.org/doc/debian-policy/ch-relationships.html
-control_content = """\
-Package: badtrack
-Version: 1.0.0
-Depends: python3, badtracksecrets
-Section: custom
-Priority: optional
-Architecture: all
-Essential: no
-Installed-Size: 1024
-Maintainer: Your Name <your-email@example.com>
-Description: Badtrack is a sample package
-"""
-with open(f"{APP_PATH}/badtrack/DEBIAN/control", 'w') as file:
-    file.write(control_content)
-
-# Create the systemd service file within the package
-service_content = f"""\
-[Unit]
-Description=BadTrack Service
-After=network.target
-
-[Service]
-Type=simple
-User=badtrackuser
-WorkingDirectory=/usr/local/bin/badtrack
-ExecStart=/usr/bin/python3 /usr/local/bin/badtrack/main.py
-Environment=HISTORY_FOLDER={HISTORY_FOLDER}
-Environment=CACHE_FOLDER={CACHE_FOLDER}
-EnvironmentFile=/var/lib/badtrack/.env
-EnvironmentFile=/var/lib/badtrack/secrets.env
+def package_directory(path):
+    """
+    Adds directory to the package filestructure.
+    Arguments:
+        Path - the path of the directory.
+    Example Usage:
+        package_directory(/var/lib/example/) - When the package is installed, the directory /var/lib/example/ will be added to the filesystem.
+    """
+    if path[0] == '/':
+        path = path[1:]
+    os.makedirs(f"{APP_PATH}/{PACKAGE_NAME}/{path}", exist_ok=True)
+    return
 
 
-[Install]
-WantedBy=multi-user.target
-"""
-with open(f"{APP_PATH}/badtrack/etc/systemd/system/badtrack.service", 'w') as file:
-    file.write(service_content)
+def package_file(path,contents=None,existing_file=None):
+    """
+    Add a file to the package.
+    Arguments:
+        Path - the path of the installed file
+        contents - If a new file is being written, this should be set to the contents of the file
+        existing_file - If instead an existing file is being added to the package, this should be the path to that file.
+    """
+    if path[0] == "/":
+         path = path[1:]
 
-# Changing the permissions of the badtrack.service file
-os.chmod(f"{APP_PATH}/badtrack/etc/systemd/system/badtrack.service", 0o644)
+    if contents == None:
+        shutil.copy(existing_file, f"{APP_PATH}/{PACKAGE_NAME}/{path}")
+        return
 
-# Create the post-installation script
-postinst_content = f"""\
-#!/bin/bash
-getent passwd badtrackuser > /dev/null || sudo useradd -r -s /bin/false badtrackuser
-# Set ownership of folders to badtrackuser
-chown -R badtrackuser:badtrackuser \"{HISTORY_FOLDER}\"
-chown -R badtrackuser:badtrackuser \"{CACHE_FOLDER}\"
-chown badtrackuser:badtrackuser \"{APP_PATH}/badtrack/var/lib/badtrack/.env\"
-systemctl enable badtrack
-systemctl daemon-reload
-systemctl restart badtrack
-"""
+    with open(f'{APP_PATH}/{PACKAGE_NAME}/{path}','w+') as file:
+        file.write(contents)
+    return
 
-with open(f"{APP_PATH}/badtrack/DEBIAN/postinst", 'w') as file:
-    file.write(postinst_content)
 
-# Make the post-installation script executable
-os.chmod(f"{APP_PATH}/badtrack/DEBIAN/postinst", 0o755)
+def format_control_file(
+    package=PACKAGE_NAME,
+    version='1.0.0',
+    depends='',
+    section='custom',
+    priority='optional',
+    architecture='all',
+    essential='no',
+    installed_size='1024',
+    maintainer='Your Name <your-email@example.com>',
+    description=f'{PACKAGE_NAME} is a sample package'):
+        """
+        Formats the control file
+        """
 
-# Build the Debian package
-subprocess.run(["dpkg-deb", "--build", f"{APP_PATH}/badtrack"],check=True)
-print("badtrack.deb package has been created.")
+        control_content = inspect.cleandoc(f"""\
+        Package: {package}
+        Version: {version}
+        Depends: {depends}
+        Section: {section}
+        Priority: {priority}
+        Architecture: {architecture}
+        Essential: {essential}
+        Installed-Size: {installed_size}
+        Maintainer: {maintainer}
+        Description: {description}
+        """)
+        control_content += "\n"
+        return control_content
+
+
+def build_package():
+    """
+    Builds the debian package
+    """
+    subprocess.run(["dpkg-deb", "--build", f"{APP_PATH}/{PACKAGE_NAME}"],check=True)
+    print(f"{PACKAGE_NAME}.deb package has been created.")
+    return
+
+
+if __name__ == '__main__':
+    # Setup text files
+
+    # Setup environment file
+    envfile_text = inspect.cleandoc(f"""\
+    EMAIL_HOST = 'relay.mailbaby.net'
+    EMAIL_PORT = '465'
+    EMAIL_FROM = 'sender@obsi.com.au'
+    EMAIL_TO = 'yannstaggl@gmail.com'
+    """)
+
+    # Setup service file
+    service_content = inspect.cleandoc(f"""\
+    [Unit]
+    Description=BadTrack Service
+    After=network.target
+
+    [Service]
+    Type=simple
+    User=badtrackuser
+    WorkingDirectory=/usr/local/bin/badtrack
+    ExecStart=/usr/bin/python3 /usr/local/bin/badtrack/main.py
+    Environment=HISTORY_FOLDER={HISTORY_FOLDER}
+    Environment=CACHE_FOLDER={CACHE_FOLDER}
+    EnvironmentFile=/var/lib/badtrack/.env
+    EnvironmentFile=/var/lib/badtrack/secrets.env
+
+    [Install]
+    WantedBy=multi-user.target
+    """)
+
+    # Setup postinst
+    postinst_content = inspect.cleandoc(f"""\
+    #!/bin/bash
+    getent passwd badtrackuser > /dev/null || sudo useradd -r -s /bin/false badtrackuser
+    # Set ownership of folders to badtrackuser
+    chown -R badtrackuser:badtrackuser \"{HISTORY_FOLDER}\"
+    chown -R badtrackuser:badtrackuser \"{CACHE_FOLDER}\"
+    chown badtrackuser:badtrackuser \"{APP_PATH}/badtrack/var/lib/badtrack/.env\"
+    systemctl enable badtrack
+    systemctl daemon-reload
+    systemctl restart badtrack
+    """)
+
+    # Setup control file
+    control_content = format_control_file(depends="badtracksecrets")
+
+    # Create the badtrack directory structure
+    package_directory("DEBIAN")
+    package_directory(CACHE_FOLDER)
+    package_directory(HISTORY_FOLDER)
+    package_directory("/etc/systemd/system/")
+    package_directory("/usr/local/bin/badtrack")
+
+    # Add files to package
+    package_file("/DEBIAN/control",contents=control_content)
+    package_file("/DEBIAN/postinst",contents=postinst_content)
+    package_file("/var/lib/badtrack/.env",contents=envfile_text)
+    package_file("/etc/systemd/system/badtrack.service",contents=service_content)
+    package_file("/usr/local/bin/badtrack/main.py",existing_file="main.py")
+
+    # Set permissions for badtrack files
+    os.chmod(f"{APP_PATH}/{PACKAGE_NAME}/DEBIAN/postinst", 0o755)
+    os.chmod(f"{APP_PATH}/{PACKAGE_NAME}/var/lib/badtrack/.env", 0o755)
+    os.chmod(f"{APP_PATH}/{PACKAGE_NAME}/var/lib/badtrack/cache",0o755)
+    os.chmod(f"{APP_PATH}/{PACKAGE_NAME}/var/lib/badtrack/history",0o755)
+    os.chmod(f"{APP_PATH}/{PACKAGE_NAME}/etc/systemd/system/badtrack.service", 0o644)
+    os.chmod(f"{APP_PATH}/{PACKAGE_NAME}/usr/local/bin/badtrack/main.py", 0o755)
+
+    # Build the debian package
+    build_package()

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ import sys
 from termios import tcflush, TCIFLUSH
 import smtplib
 from uuid import uuid4
-
+import inspect
 
 from urllib.error import URLError
 import urllib.request
@@ -150,35 +150,34 @@ def check_date(store, date_to_check):
     ] #Contains the difference between the current details and the previous history file.
 
     if diff:
-        pprint(diff)
         send_email(os.environ['EMAIL_HOST'],
                    int(os.environ['EMAIL_PORT']),
                    os.environ['EMAIL_USER'],
                    os.environ['EMAIL_PASSWORD'],
                    os.environ['EMAIL_FROM'],
                    os.environ['EMAIL_TO'],
-                   pformat(diff).encode('utf-8'), #pprint.pformat collides with pprint.pprint
+                   pformat(diff),
                    'Updated booking details')
 
 def send_email(email_host, email_port, user, password, email_from, email_to, email_body, email_subject):
     _user, email_domain = email_from.split('@', 1)
-    email_text = f"""\
+    email_text = inspect.cleandoc(f"""\
     Message-ID: <{uuid4()}@{email_domain}>
     From: Python SMTP Sender <%s>
     To: %s
     Subject: %s
 
     %s
-    """ % (email_from, email_to, email_subject, email_body)
+    """) % (email_from, email_to, email_subject, email_body)
     try:
-        if email_host == 465:
+        if email_port == 465:
             smtp_server = smtplib.SMTP_SSL(email_host, email_port)
         else:
-            smtp_server = smtplib.SMTP(email_host,email_port)
+            smtp_server = smtplib.SMTP(email_host, email_port)
         smtp_server.ehlo()        
         if user:
             smtp_server.login(user, password)
-        smtp_server.sendmail(email_from, email_to, email_text)
+        smtp_server.sendmail(email_from, email_to, email_text.encode('UTF-8'))
         smtp_server.close()
         print ("Email sent successfully!")
     except Exception as ex:
@@ -206,11 +205,11 @@ def run_loop(history_folder):
         # so an accidental Enter key press at the beginning of the programme will make the following
         # select.select code receive the keystroke skipping the while loop potentially multiple times
         # https://stackoverflow.com/questions/55525716/python-input-takes-old-stdin-before-input-is-called
-        tcflush(sys.stdin, TCIFLUSH)
+        #tcflush(sys.stdin, TCIFLUSH)
 
         # Wait for input or timeout
         # https://stackoverflow.com/questions/1335507/keyboard-input-with-timeout
-        select.select([sys.stdin], [], [], wait_seconds)
+        #select.select([sys.stdin], [], [], wait_seconds)
 
 if __name__ == '__main__':
     try:

--- a/readme.md
+++ b/readme.md
@@ -3,16 +3,16 @@
 
 Build badtracksecrets:
 
-`python3 ./build_secrets.py -u <Email Username> -p <Email Password>`
+`EMAIL_USER=\<username> EMAIL_PASSWORD=\<password> ./build_secrets.py
 
 Then, Build badtrack:
 
-`python3 ./build_badtrack.py`
+`./build_badtrack.py`
 
 Then, install badtrack and badtracksecrets:
 
-`sudo dpkg -i badtrack.deb badtracksecrets.deb`
+`dpkg -i badtrack.deb badtracksecrets.deb`
 
 Check that everything is working:
 
-`sudo systemctl status badtrack`
+`systemctl status badtrack`


### PR DESCRIPTION
emails should now work and running as a service should no longer cause crashes.

build_secrets.py now properly takes environment variables as input (EMAIL_USER=user EMAIL_PASSWORD=pass ./build_secrets.py)

postinst class removed because looking at it again I agree it was pointless

Also refactored build_badtrack in the same was as build_secrets. Different steps (i.e. build filestructure, place files, set permissions) are now separated with similar operations next to each other instead of scattered throughout the file. I believe this makes the code less prone to bugs, and when they do arise they're much easier to fix, and the code is easy to copy paste and reuse across files.

Removed .env.example as it's now redundant due to .env now being properly built by the build script. 

The readme has also been updated to match the changes.

Currently, when variables are passed into build_secret they can either be enclosed in quotes or be without them. This makes it less prone to mistakes, but does raise a compatibility issue with usernames/passwords that start and end with the same quote character.